### PR TITLE
Multiarch local docker builds

### DIFF
--- a/docker/localbuild.amd64.Dockerfile
+++ b/docker/localbuild.amd64.Dockerfile
@@ -1,5 +1,5 @@
 FROM --platform=amd64 gcr.io/distroless/static-debian11:nonroot
 USER 20000:20000
-ADD --chmod=555 build/bin/external-dns-hetzner-webhook-arm64 /opt/external-dns-hetzner-webhook/app
+ADD --chmod=555 build/bin/external-dns-hetzner-webhook-amd64 /opt/external-dns-hetzner-webhook/app
 
 ENTRYPOINT ["/opt/external-dns-hetzner-webhook/app"]


### PR DESCRIPTION
Although the arch-specific targets are used mainly for development, as the images are released through Goreleaser, it is useful to have both the amd64 and arm64 images at once when testing.