### PR TITLE
📚 Fix typo in documentation

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -878,6 +878,7 @@ github.com/valyala/quicktemplate v1.8.0/go.mod h1:qIqW8/igXt8fdrUln5kOSb+KWMaJ4Y
 github.com/vburenin/ifacemaker v1.3.0/go.mod h1:SxTD9m+6uBQyhd0aohV7R4iirO+l9mEoTn4nSe67vMs=
 github.com/vburenin/ifacemaker v1.3.1-0.20251209121141-a6d9756091ba/go.mod h1:Car3Ss6dMkORtaciIcBu5DlzKQaawLS5f4nogJjRHr0=
 github.com/vburenin/ifacemaker v1.3.1-0.20260311040944-7e11f0e9a962/go.mod h1:b4D8A83/PDaTHGJrB9ySyoYLqXUhvgbkxZtxCHCg/A0=
+github.com/vburenin/ifacemaker v1.3.1-0.20260417025851-7bffe3f42628/go.mod h1:VATsDjLUQfeo2Thkn/OuAuQX5xpGz//yhj7BwF1jAJ0=
 github.com/vektah/gqlparser/v2 v2.5.1/go.mod h1:mPgqFBu/woKTVYWyNk8cO3kh4S/f4aRFZrvOnp3hmCs=
 github.com/vektah/gqlparser/v2 v2.5.14/go.mod h1:WQQjFc+I1YIzoPvZBhUQX7waZgg3pMLi0r8KymvAE2w=
 github.com/vektah/gqlparser/v2 v2.5.26/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
@@ -1085,6 +1086,7 @@ golang.org/x/sys v0.23.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.24.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/telemetry v0.0.0-20240521205824-bda55230c457/go.mod h1:pRgIJT+bRLFKnoM1ldnzKoxTIn14Yxz928LQRYYgIN0=
 golang.org/x/telemetry v0.0.0-20260311193753-579e4da9a98c/go.mod h1:TpUTTEp9frx7rTdLpC9gFG9kdI7zVLFTFFlqaH2Cncw=
+golang.org/x/telemetry v0.0.0-20260409153401-be6f6cb8b1fa/go.mod h1:kHjTxDEnAu6/Nl9lDkzjWpR+bmKfxeiRuSDlsMb70gE=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.24.0 h1:Mh5cbb+Zk2hqqXNO7S1iTjEphVL+jb8ZWaqh/g+JWkM=
 golang.org/x/term v0.24.0/go.mod h1:lOBK/LVxemqiMij05LGJ0tzNr8xlmwBRJ81PX6wVLH8=

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -12,7 +12,7 @@ nav:
   - Getting started:
     - Requirements: requirements.md
     - Deployment: deployment.md
-    - Upgrading from prevoius versions: upgrading.md
+    - Upgrading from previous versions: upgrading.md
   - Configuration:
     - Environment variables: environment-variables.md
   - Beyond basic usage:


### PR DESCRIPTION
The word _previous_ was spelled wrong. Also, updated go.work.sum with current checksums.